### PR TITLE
[build] Build all Dune packages in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,13 @@
+.PHONY: all
+all: build
+
+PKG_SET=coq-lsp/coq-lsp.install rocq/coq-core.install rocq/rocq-core.install rocq/rocq-runtime.install stdlib/rocq-stdlib.install stdlib/coq-stdlib.install coq-waterproof/coq-waterproof.install
+
+.PHONY: build
+build: rocq/config/coq_config.ml
+	dune build $(PKG_SET)
+
+# Ideally we could regenerate this on Rocq updates, usually not needed
 rocq/config/coq_config.ml: rocq
 	EPATH=$(shell pwd) \
 	&& cd rocq \
@@ -12,9 +22,7 @@ rocq/config/coq_config.ml: rocq
 clean:
 	dune clean
 
-.PHONY: build
-build:
-	dune build -p coq-waterproof
-
-.PHONY: all
-all: rocq/config/coq_config.ml build
+# Launch where the _CoqProject file is
+.PHONY: launch
+launch: build
+	dune exec -- code coq-waterproof/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Building is done using `make all`.
 To use `coq-lsp` in vscode, one can then run
 
 ```
-dune exec -- code .
+dune exec -- code coq-waterproof
 ```
 
 from the root directory.
@@ -16,17 +16,3 @@ To execute tests against the Waterproof exercises, run
 ```
 dune test
 ```
-
-## Alternative instructions
-
-To get the setup to work, one may need to execute
-```
-opam install ./coq-lsp/coq-lsp.opam --deps-only
-```
-from the root directory.
-
-From there, one should be able to just run
-```
-dune build
-```
-from the root directory.

--- a/dune-workspace
+++ b/dune-workspace
@@ -1,0 +1,2 @@
+(lang dune 3.16)
+(profile release)


### PR DESCRIPTION
We explicitly build all dune packages in Makefile's build target, this ensures a more stable build setup.

We must do this explicit call as we mark the submodules as vendored, which makes package building "lazy".

This is the right thing to do, we don't want to build / run unrelated stuff for vendored packaged like documentation or tests.

We also make the `all` target the default for Make.

I've set `--profile=release` as the build default, this makes
`coq-lsp` plugin loading and .vo file compilation much faster, at the
cost of slower compilation of .ml files.
